### PR TITLE
Update Plugin.lua

### DIFF
--- a/Place1/Workspace/GitSync/Plugin.lua
+++ b/Place1/Workspace/GitSync/Plugin.lua
@@ -115,13 +115,13 @@ local settingBTN_template = settingsuiClone.Frame.ScrollingFrame.template
 
 
 local textbox = frame.repoBOX
-textbox.Text = erepo
+textbox.PlaceholderText = erepo
 
 local tokenBox = frame.tokenBOX
-tokenBox.Text = key
+tokenBox.PlaceholderText = key
 
 local branchBox = settingsuiClone.Frame.branchBOX
-branchBox.Text = branch
+branchBox.PlaceholderText = branch
 
 frame.Close.MouseButton1Click:Connect(function()
 	isOpenUI = not isOpenUI


### PR DESCRIPTION
Change the default text of the textboxes to be displayed as placeholder text. That will make the text disappear when clients start typing.

The image below shows the change as well (Ignore Grammarly. It doesn't like GitHub code lol)

BEFORE:
![Screenshot 2025-03-11 9 39 33 AM](https://github.com/user-attachments/assets/c60916b6-e1ef-4232-8ce0-30034f0c6b09)

AFTER:
![Screenshot 2025-03-11 9 39 50 AM](https://github.com/user-attachments/assets/ec4f9567-469b-432a-8f67-19222311a61a)